### PR TITLE
prevent all moles from rerendering unnecessarily

### DIFF
--- a/src/components/Mole.js
+++ b/src/components/Mole.js
@@ -4,6 +4,15 @@ import './Mole.css';
 
 // props = active, id, onWhack
 class Mole extends Component {
+
+  shouldComponentUpdate(nextProps) {
+    if (nextProps.active !== this.props.active) {
+      return true;
+    }
+
+    return false;
+  }
+
   setContainerClassName() {
     const { active } = this.props;
     return `mole-container ${active ? "active" : "inactive"}`;


### PR DESCRIPTION
Before Changes:
-Every time a mole changed status, all moles rerendered

After Changes:
-Only the mole which has its status changed is rerendered

How to test:
-Insert a console log in render method of Mole.js component and observe frequency of logs when a single mole changes status